### PR TITLE
Random-balanced-begin-random-too

### DIFF
--- a/src/utils/balancedRandom.js
+++ b/src/utils/balancedRandom.js
@@ -1,13 +1,8 @@
 import { weightedRandomIndex } from "./weightedRandom";
 
 const getProbsFromCounts = (counts) => {
-  if (counts.includes(0)) {
-    const relProbs = counts.map((n) => (n === 0 ? 1 : 0));
-    return relProbs;
-  } else {
-    const relProbs = counts.map((n) => 1 / n);
-    return relProbs;
-  }
+  const zeroProb = counts.length / 2;
+  return counts.map((n) => (n === 0 ? zeroProb : 1 / n));
 };
 
 const balancedRandomIndex = (counts) => {


### PR DESCRIPTION
This is pretty cool
1. Instead of forcing all cases to show up at least once
before doing our fancy math, we can assign cases with a
zero probability a constant value.
2. Having this value be dependant on the number of cases being tested
makes it such that the probability of getting a case that has not
show up when all others have, is roughly constant for a case selection
of any size.
That is, if you have a fixed number for zero probability
such as 3, then for large case selections (say you select 20 cases),
then the probability of getting the case that has not shown up
will be quite low

3. We divide by 2, just because this makes the probabilities feel better
not doing so makes it feel as though
the cases that have shown up 0 times
are being forced to show up

4. This is all a bit wishy washy because...
It's fixing a wishy washy problem.
The solution is what feels good when doing solves
And this feels good.
If you do want to change this mechanism later, don't fret, and just see what feels
good for selections of different sizes (2 to ~15)