### PR TITLE
Dark Mode through Context

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import SettingsPage from "./components/pages/settingsPage";
 import PasswordReset from "./components/passwordReset";
 import SignUp from "./components/signUp";
 import LogIn from "./components/logIn";
-import useDarkMode, { DarkModeContext } from "./hooks/useDarkMode";
+import DarkModeContext, { useDarkMode } from "./hooks/useDarkMode";
 import useUserDoc from "./hooks/useUserDoc";
 
 function App() {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import { Navbar as NavbarRB, Nav, NavDropdown, Button } from "react-bootstrap";
 import { Link, NavLink } from "react-router-dom";
 import { FaIcon } from "../fontAwesome";
 import { auth, useAuthState } from "../fire";
-import { DarkModeContext } from "../hooks/useDarkMode";
+import DarkModeContext from "../hooks/useDarkMode";
 
 export default function Navbar() {
   const [expanded, setExpanded] = useState(false);

--- a/src/components/caseSetDashboard.jsx
+++ b/src/components/caseSetDashboard.jsx
@@ -3,7 +3,7 @@ import { Button, Col, Row } from "react-bootstrap";
 import { FaIcon } from "../fontAwesome";
 import _ from "lodash";
 import useLocalStorage from "../hooks/useLocalStorage";
-import { DarkModeContext } from "../hooks/useDarkMode";
+import DarkModeContext from "../hooks/useDarkMode";
 import ollCaseSet from "../data/ollCaseSet";
 import pllCaseSet from "../data/pllCaseSet";
 import eollCaseSet from "../data/eollCaseSet";

--- a/src/components/caseSetTable.jsx
+++ b/src/components/caseSetTable.jsx
@@ -15,7 +15,7 @@ import MultiProgressBar from "./common/multiProgressBar";
 import { UserContext } from "../fire";
 import { dispDur, dispDecimal, dispOverline } from "../utils/displayValue";
 import { getCaseSetDocRef } from "../utils/writeCases";
-import { DarkModeContext } from "../hooks/useDarkMode";
+import DarkModeContext from "../hooks/useDarkMode";
 import useCaseModal from "../hooks/useCaseModal";
 import useWindowDimensions from "../hooks/useWindowDimensions";
 

--- a/src/components/common/centerCard.jsx
+++ b/src/components/common/centerCard.jsx
@@ -2,7 +2,7 @@ import { useContext } from "react";
 import Container from "react-bootstrap/Container";
 import Card from "react-bootstrap/Card";
 import Alert from "react-bootstrap/Alert";
-import { DarkModeContext } from "../../hooks/useDarkMode";
+import DarkModeContext from "../../hooks/useDarkMode";
 
 export default function CenterCard({ title, content, textBelowCard, error }) {
   const { darkMode } = useContext(DarkModeContext);

--- a/src/components/common/cubing/caseSetCard.jsx
+++ b/src/components/common/cubing/caseSetCard.jsx
@@ -6,7 +6,7 @@ import Row from "react-bootstrap/Row";
 import { FaIcon } from "../../../fontAwesome";
 import _ from "lodash";
 import CaseImage from "./cubeImage";
-import { DarkModeContext } from "../../../hooks/useDarkMode";
+import DarkModeContext from "../../../hooks/useDarkMode";
 
 export default function CaseSetCard(props) {
   const { cases, details } = props.caseSet;

--- a/src/components/common/reactTable.jsx
+++ b/src/components/common/reactTable.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import Table from "react-bootstrap/Table";
-import { DarkModeContext } from "../../hooks/useDarkMode";
+import DarkModeContext from "../../hooks/useDarkMode";
 import { FaIcon } from "../../fontAwesome";
 
 // Source: https://react-table.tanstack.com/docs/examples/data-driven-classes-and-styles

--- a/src/components/feedbackCard.jsx
+++ b/src/components/feedbackCard.jsx
@@ -3,7 +3,7 @@ import { FaIcon } from "../fontAwesome";
 import { Button, Card } from "react-bootstrap";
 import _ from "lodash";
 import ButtonGroupToggle from "./common/buttonGroupToggle";
-import { DarkModeContext } from "../hooks/useDarkMode";
+import DarkModeContext from "../hooks/useDarkMode";
 
 export default function FeedbackCard({ currentSolve, solves, setSolves }) {
   const { darkMode } = useContext(DarkModeContext);

--- a/src/components/pages/learnPage.jsx
+++ b/src/components/pages/learnPage.jsx
@@ -4,7 +4,7 @@ import { FaIcon } from "../../fontAwesome";
 import _ from "lodash";
 import CaseImage from "../common/cubing/cubeImage";
 import ScrambleDisplay from "../common/cubing/scrambleDisplay";
-import { DarkModeContext } from "../../hooks/useDarkMode";
+import DarkModeContext from "../../hooks/useDarkMode";
 
 export default function LearnPage(props) {
   const [algVisible, setAlgVisible] = useState(true);

--- a/src/components/pages/settingsPage.jsx
+++ b/src/components/pages/settingsPage.jsx
@@ -6,7 +6,7 @@ import Card from "react-bootstrap/Card";
 import Form from "react-bootstrap/Form";
 import Container from "react-bootstrap/Container";
 import ListGroup from "react-bootstrap/ListGroup";
-import useDarkMode, { DarkModeContext } from "../../hooks/useDarkMode";
+import DarkModeContext from "../../hooks/useDarkMode";
 import TrainSettings from "../trainSettings";
 const SettingsPage = () => {
   const { darkMode, setDarkMode } = useContext(DarkModeContext);

--- a/src/components/pages/testPage.jsx
+++ b/src/components/pages/testPage.jsx
@@ -12,7 +12,7 @@ import { dispDur } from "../../utils/displayValue";
 import { writeCasesToFirebase } from "../../utils/writeCases";
 import { getSTM, randomYRot } from "../../utils/algTools";
 import balancedRandomIndex from "../../utils/balancedRandom";
-import { DarkModeContext } from "../../hooks/useDarkMode";
+import DarkModeContext from "../../hooks/useDarkMode";
 import useWindowDimensions from "../../hooks/useWindowDimensions";
 import useModal from "../../hooks/useModal";
 

--- a/src/hooks/useCaseModal.jsx
+++ b/src/hooks/useCaseModal.jsx
@@ -9,7 +9,7 @@ import DeletableOption from "../components/common/deletableOption";
 import CenterModalHeader from "../components/common/centerModalHeader";
 import useModal from "./useModal";
 import { setDocument, getCaseSetDocRef } from "../utils/writeCases";
-import { DarkModeContext } from "../hooks/useDarkMode";
+import DarkModeContext from "../hooks/useDarkMode";
 
 const CaseModalContent = ({ cas, caseSetDetails, hideModal }) => {
   const [options, setOptions] = useState();

--- a/src/hooks/useDarkMode.jsx
+++ b/src/hooks/useDarkMode.jsx
@@ -1,9 +1,10 @@
 import useLocalStorage from "./useLocalStorage";
 import { useEffect, createContext } from "react";
 
-export const DarkModeContext = createContext(true);
+const DarkModeContext = createContext(true);
+export default DarkModeContext;
 
-export default function useDarkMode() {
+export function useDarkMode() {
   const [darkMode, setDarkMode] = useLocalStorage("dark-mode-enabled", true);
 
   useEffect(() => {


### PR DESCRIPTION
### React Docs say do this
 [When to Use Context](https://reactjs.org/docs/context.html#when-to-use-context)
> Context is designed to share data that can be considered “global” for a tree of React components, such as the current authenticated user, **theme**, or preferred language.

The official React documentation lists **theme** (dark mode is a theme) as a typical use case for React's context. I should do this with the authenticated user next. @ThisTemba Remind me to do that.

This was a pretty simple switch, just remember not to use useDarkMode anywhere but App.js