### PR TITLE
Squash Build Warnings

### DIFF
--- a/src/components/caseSetTable.jsx
+++ b/src/components/caseSetTable.jsx
@@ -24,7 +24,7 @@ import {
 } from "../utils/learnedStatus";
 
 export default function CaseSetTable(props) {
-  const { caseSet } = props;
+  const { caseSet, setSelectedCases } = props;
   const [data, setData] = useState(caseSet.cases || {});
   const { userDoc } = useContext(UserContext);
   const { darkMode } = useContext(DarkModeContext);
@@ -33,13 +33,17 @@ export default function CaseSetTable(props) {
   const [caseModalId, setCaseModalId] = useState(null);
   const { width } = useWindowDimensions();
 
-  const userTrainSettings = userDoc?.data()?.settings?.trainSettings;
+  const userTrainSettings = useMemo(
+    () => userDoc?.data()?.settings?.trainSettings,
+    [userDoc]
+  );
+  const currentCase = _.find(data, ["id", caseModalId]);
 
   useEffect(() => {
     setCaseModalContent();
-    const cas = _.find(data, ["id", caseModalId]);
-    setCaseModalContent(cas, caseSet.details);
-  }, [showing, _.find(data, ["id", caseModalId])]);
+    setCaseModalContent(currentCase, caseSet.details);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showing, currentCase, caseSet.details]);
 
   useEffect(() => {
     setData(caseSet.cases);
@@ -179,7 +183,7 @@ export default function CaseSetTable(props) {
         sortType: sortStatus,
       },
     ],
-    [windowIsWide]
+    [windowIsWide, caseSet.details, hasUniqueGroups, userTrainSettings]
   );
 
   const getPropNotLearnedProps = ({ column, row, isAggregated, value }) => {
@@ -240,8 +244,8 @@ export default function CaseSetTable(props) {
   useEffect(() => {
     const selectedRowIds = table.state.selectedRowIds;
     const selectedCases = data.filter((unused, i) => selectedRowIds[i]);
-    props.setSelectedCases(selectedCases);
-  }, [table.state.selectedRowIds]);
+    setSelectedCases(selectedCases);
+  }, [table.state.selectedRowIds, setSelectedCases, data]);
 
   return (
     <>

--- a/src/components/caseSetTable.jsx
+++ b/src/components/caseSetTable.jsx
@@ -227,9 +227,9 @@ export default function CaseSetTable(props) {
   const initialState = {
     groupBy: hasUniqueGroups ? ["group"] : [],
     sortBy: [{ id: "status", desc: true }],
-    hiddenColumns: columns.map((column) => {
-      if (column.show === false) return column.accessor || column.id;
-    }),
+    hiddenColumns: columns
+      .filter((c) => c.show === false)
+      .map((c) => c.accessor || c.id),
   };
 
   const table = useTable(

--- a/src/components/common/CaseModalContent.jsx
+++ b/src/components/common/CaseModalContent.jsx
@@ -18,9 +18,9 @@ export default function CaseModalContent({ cas, caseSetDetails, hideModal }) {
   const [caseDoc, setCaseDoc] = useState(null);
   const { user } = useContext(UserContext);
   const { darkMode } = useContext(DarkModeContext);
-  const customOption = { value: null, label: "Custom" };
 
   useEffect(() => {
+    const customOption = { value: null, label: "Custom" };
     const initialOptions = cas.algs.map((a) => ({ value: a, label: a }));
     setOptions([customOption, ...initialOptions]);
     setSelectedOption(newOption(cas.alg));

--- a/src/components/common/CaseModalContent.jsx
+++ b/src/components/common/CaseModalContent.jsx
@@ -24,7 +24,7 @@ export default function CaseModalContent({ cas, caseSetDetails, hideModal }) {
     const initialOptions = cas.algs.map((a) => ({ value: a, label: a }));
     setOptions([customOption, ...initialOptions]);
     setSelectedOption(newOption(cas.alg));
-  }, []);
+  }, [cas.alg, cas.algs]);
 
   const newOption = (alg, deletable = false) => ({
     label: alg,

--- a/src/components/common/cubing/cubeImage.jsx
+++ b/src/components/common/cubing/cubeImage.jsx
@@ -7,6 +7,7 @@ import _ from "lodash";
 const CubeImageInternal = (props) => {
   const imageRef = useRef(null);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => cubeSVG(imageRef.current, { ...props, colorScheme }), []);
 
   return <div ref={imageRef}></div>;

--- a/src/components/common/cubing/solveList.jsx
+++ b/src/components/common/cubing/solveList.jsx
@@ -78,10 +78,7 @@ export default function SolveList({ solves, onPenalty, onDeleteSolve }) {
 
   const renderSolveListTable = (solves) => {
     const reversedSolves = [...solves].reverse();
-    const btnProps = {
-      href: "javascript:;",
-      style: { color: buttonsColor },
-    };
+    const btnProps = { href: "#", style: { color: buttonsColor } };
 
     const onClickTime = (s) => {
       setSelectedSolveDateTime(s.dateTime);
@@ -122,12 +119,24 @@ export default function SolveList({ solves, onPenalty, onDeleteSolve }) {
               >
                 <th className="align-middle">{s.solveNumber + "."}</th>
                 <td className="align-middle">
-                  <a {...btnProps} onClick={() => onClickTime(s)}>
+                  <a
+                    {...btnProps}
+                    onClick={(e) => {
+                      e.preventDefault(); // hack to prevent href from being followed
+                      onClickTime(s);
+                    }}
+                  >
                     {dispDur(s.dur) + (s.penalty === "+2" ? "+" : "")}
                   </a>
                 </td>
                 <td className="align-middle">
-                  <a {...btnProps} onClick={() => onDeleteSolve(s.dateTime)}>
+                  <a
+                    {...btnProps}
+                    onClick={(e) => {
+                      e.preventDefault(); // hack to prevent href from being followed
+                      onDeleteSolve(s.dateTime);
+                    }}
+                  >
                     <FaIcon icon="trash" size="sm" />
                   </a>
                 </td>

--- a/src/components/common/cubing/solveList.jsx
+++ b/src/components/common/cubing/solveList.jsx
@@ -12,7 +12,7 @@ import ButtonGroupToggle from "../buttonGroupToggle";
 import TimeDisplay from "./timeDisplay";
 
 export default function SolveList({ solves, onPenalty, onDeleteSolve }) {
-  const [ModalComponent, showModal, unused, setModalContent] = useModal();
+  const [ModalComponent, showModal, , setModalContent] = useModal();
   const [selectedSolveDateTime, setSelectedSolveDateTime] = useState(null);
   const { darkMode } = useContext(DarkModeContext);
   const { xs } = useWindowDimensions();

--- a/src/components/common/cubing/solveList.jsx
+++ b/src/components/common/cubing/solveList.jsx
@@ -23,58 +23,12 @@ export default function SolveList({ solves, onPenalty, onDeleteSolve }) {
     if (solve) {
       const content = {
         title: `Solve ${solve?.solveNumber}`,
-        body: renderModalBody(solve),
+        body: renderModalBody(solve, onPenalty),
       };
       setModalContent(content);
     }
-  }, [solves]);
-
-  const renderPenaltyButtons = (s) => {
-    const penaltyButtons = [
-      { content: "None", id: "", color: "success" },
-      { content: "+2", id: "+2", color: "warning" },
-      { content: "DNF", id: "DNF", color: "danger" },
-    ];
-    return (
-      <ButtonGroupToggle
-        buttons={penaltyButtons}
-        activeId={s.penalty}
-        onSelect={(id) => {
-          onPenalty(s.dateTime, id);
-        }}
-      ></ButtonGroupToggle>
-    );
-  };
-
-  const renderModalBody = (s) => {
-    const timeOptions = { hour: "2-digit", minute: "2-digit" };
-    const time = new Date(s.dateTime).toLocaleTimeString([], timeOptions);
-    const rows = [
-      { label: "Scramble", value: s.scramble },
-      { label: "Time", value: time },
-      { label: "Penalty", value: renderPenaltyButtons(s) },
-    ];
-    return (
-      <>
-        <TimeDisplay
-          formattedTime={dispDur(s.dur) + (s.penalty === "+2" ? "+" : "")}
-          fontSize={100}
-        ></TimeDisplay>
-        <Table className="text-center m-0">
-          <colgroup>
-            <col span="1" style={{ width: "30%" }} />
-            <col span="1" style={{ width: "70%" }} />
-          </colgroup>
-          {rows.map((row) => (
-            <tr>
-              <th className="align-middle">{row.label}</th>
-              <td className="align-middle">{row.value}</td>
-            </tr>
-          ))}
-        </Table>
-      </>
-    );
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [solves, renderModalBody, onPenalty, selectedSolveDateTime]);
 
   const renderSolveListTable = (solves) => {
     const reversedSolves = [...solves].reverse();
@@ -84,7 +38,7 @@ export default function SolveList({ solves, onPenalty, onDeleteSolve }) {
       setSelectedSolveDateTime(s.dateTime);
       showModal({
         title: `Solve ${s.solveNumber}`,
-        body: renderModalBody(s),
+        body: renderModalBody(s, onPenalty),
       });
       document.activeElement.blur();
     };
@@ -154,6 +108,52 @@ export default function SolveList({ solves, onPenalty, onDeleteSolve }) {
         {renderSolveListTable(solves)}
       </SimpleBar>
       <ModalComponent />
+    </>
+  );
+}
+function renderPenaltyButtons(s, onPenalty) {
+  const penaltyButtons = [
+    { content: "None", id: "", color: "success" },
+    { content: "+2", id: "+2", color: "warning" },
+    { content: "DNF", id: "DNF", color: "danger" },
+  ];
+  return (
+    <ButtonGroupToggle
+      buttons={penaltyButtons}
+      activeId={s.penalty}
+      onSelect={(id) => {
+        onPenalty(s.dateTime, id);
+      }}
+    ></ButtonGroupToggle>
+  );
+}
+
+function renderModalBody(s, onPenalty) {
+  const timeOptions = { hour: "2-digit", minute: "2-digit" };
+  const time = new Date(s.dateTime).toLocaleTimeString([], timeOptions);
+  const rows = [
+    { label: "Scramble", value: s.scramble },
+    { label: "Time", value: time },
+    { label: "Penalty", value: renderPenaltyButtons(s, onPenalty) },
+  ];
+  return (
+    <>
+      <TimeDisplay
+        formattedTime={dispDur(s.dur) + (s.penalty === "+2" ? "+" : "")}
+        fontSize={100}
+      ></TimeDisplay>
+      <Table className="text-center m-0">
+        <colgroup>
+          <col span="1" style={{ width: "30%" }} />
+          <col span="1" style={{ width: "70%" }} />
+        </colgroup>
+        {rows.map((row) => (
+          <tr>
+            <th className="align-middle">{row.label}</th>
+            <td className="align-middle">{row.value}</td>
+          </tr>
+        ))}
+      </Table>
     </>
   );
 }

--- a/src/components/common/cubing/timer.jsx
+++ b/src/components/common/cubing/timer.jsx
@@ -61,61 +61,64 @@ export default function Timer(props) {
     return solve;
   };
 
-  const handleTouchEnd = (e) => {
-    const timerState = timerStateRef.current;
-    const cancelling = timerState === "armed";
-    const coolingDown = timerState === "cooldown";
-    if (cancelling || coolingDown) {
-      e.key = " ";
-      e.preventDefault();
-      handleKeyUp(e);
-    }
-  };
-
-  const handleKeyUp = (e) => {
-    if (disabledRef.current) return;
-    const timerState = timerStateRef.current;
-    if (e.key === " ") {
-      const timerStateMap = { armed: "on", cooldown: "ready", arming: "ready" };
-      setTimerState(timerStateMap[timerState]);
-      if (timerState === "arming") {
-        clearTimeout(timeoutRef.current);
-        setTime(0);
-      }
-    }
-  };
-
-  const handleTouchStart = (e) => {
-    const isTouchingTimer = timerRef.current.contains(e.target);
-    const timerOn = timerStateRef.current === "on";
-    if (isTouchingTimer || timerOn) {
-      e.key = " ";
-      e.preventDefault();
-      handleKeyDown(e);
-    }
-  };
-
-  const handleKeyDown = (e) => {
-    if (disabledRef.current) return;
-    const timerState = timerStateRef.current;
-    const onNewSolve = onNewSolveRef.current;
-    if (timerState === "on") {
-      setTimerState("cooldown");
-      onNewSolve(getNewSolve());
-    }
-    if (e.key === " ") {
-      e.preventDefault(); // no scroll
-      if (timerState === "ready") {
-        setTimerState("arming");
-        timeoutRef.current = setTimeout(() => {
-          setTimerState("armed");
-          setTime(0);
-        }, armingTime);
-      }
-    }
-  };
-
   useEffect(() => {
+    const handleTouchEnd = (e) => {
+      const timerState = timerStateRef.current;
+      const cancelling = timerState === "armed";
+      const coolingDown = timerState === "cooldown";
+      if (cancelling || coolingDown) {
+        e.key = " ";
+        e.preventDefault();
+        handleKeyUp(e);
+      }
+    };
+
+    const handleKeyUp = (e) => {
+      if (disabledRef.current) return;
+      const timerState = timerStateRef.current;
+      if (e.key === " ") {
+        const timerStateMap = {
+          armed: "on",
+          cooldown: "ready",
+          arming: "ready",
+        };
+        setTimerState(timerStateMap[timerState]);
+        if (timerState === "arming") {
+          clearTimeout(timeoutRef.current);
+          setTime(0);
+        }
+      }
+    };
+
+    const handleTouchStart = (e) => {
+      const isTouchingTimer = timerRef.current.contains(e.target);
+      const timerOn = timerStateRef.current === "on";
+      if (isTouchingTimer || timerOn) {
+        e.key = " ";
+        e.preventDefault();
+        handleKeyDown(e);
+      }
+    };
+
+    const handleKeyDown = (e) => {
+      if (disabledRef.current) return;
+      const timerState = timerStateRef.current;
+      const onNewSolve = onNewSolveRef.current;
+      if (timerState === "on") {
+        setTimerState("cooldown");
+        onNewSolve(getNewSolve());
+      }
+      if (e.key === " ") {
+        e.preventDefault(); // no scroll
+        if (timerState === "ready") {
+          setTimerState("arming");
+          timeoutRef.current = setTimeout(() => {
+            setTimerState("armed");
+            setTime(0);
+          }, armingTime);
+        }
+      }
+    };
     const listeners = [
       { type: "touchstart", listener: handleTouchStart },
       { type: "touchend", listener: handleTouchEnd },
@@ -130,7 +133,7 @@ export default function Timer(props) {
     return () => {
       listeners.forEach((l) => removeListener(l.type, l.listener));
     };
-  }, []);
+  }, [armingTime]);
 
   // Source: https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting
   return (

--- a/src/components/pages/learnPage.jsx
+++ b/src/components/pages/learnPage.jsx
@@ -8,6 +8,7 @@ import BackButton from "../common/backButton";
 import DarkModeContext from "../../hooks/useDarkMode";
 
 export default function LearnPage(props) {
+  const { selectedCases } = props;
   const [algVisible, setAlgVisible] = useState(true);
   const [currentCase, setCurrentCase] = useState(props.selectedCases[0]);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -28,8 +29,8 @@ export default function LearnPage(props) {
   };
 
   useEffect(() => {
-    setCurrentCase(props.selectedCases[currentIndex]);
-  }, [currentIndex]);
+    setCurrentCase(selectedCases[currentIndex]);
+  }, [currentIndex, selectedCases]);
 
   const handleBackButton = () => {
     props.history.push("/train");

--- a/src/components/pages/learnPage.jsx
+++ b/src/components/pages/learnPage.jsx
@@ -103,6 +103,7 @@ export default function LearnPage(props) {
           <Card>
             <Card.Body>
               <iframe
+                title="alg"
                 frameBorder="0"
                 width="250"
                 height="290"

--- a/src/components/pages/timePage.jsx
+++ b/src/components/pages/timePage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from "react";
+import React, { useContext } from "react";
 import { Button, Container, Row } from "react-bootstrap";
 import firebase, {
   UserContext,
@@ -49,9 +49,6 @@ export default function TimePage() {
     }));
     return data;
   }
-  useEffect(() => {
-    if (session.name === null) handleNewSession();
-  }, []);
 
   const saveCurrentSession = (session) => {
     getUserDocRef(user)
@@ -153,6 +150,8 @@ export default function TimePage() {
     { end: 50, color: "#d63384" },
     { end: 100, color: "#dc3545" },
   ];
+
+  if (session.name === null) handleNewSession();
 
   return (
     <>

--- a/src/components/sessionsChart.jsx
+++ b/src/components/sessionsChart.jsx
@@ -10,9 +10,9 @@ import {
   Line,
   Scatter,
   ErrorBar,
-  AreaChart,
-  Area,
-  ReferenceLine,
+  // AreaChart,
+  // Area,
+  // ReferenceLine,
 } from "recharts";
 import { Card, Table, Button } from "react-bootstrap";
 import _ from "lodash";
@@ -69,10 +69,10 @@ export default function SessionsChart({ sessionGroup }) {
   };
 
   const renderSessionModalBody = (sesh) => {
-    const p10 = sesh.percentiles?.p10;
-    const p90 = sesh.percentiles?.p90;
-    const q1 = sesh.quartiles?.q1;
-    const q3 = sesh.quartiles?.q3;
+    // const p10 = sesh.percentiles?.p10;
+    // const p90 = sesh.percentiles?.p90;
+    // const q1 = sesh.quartiles?.q1;
+    // const q3 = sesh.quartiles?.q3;
 
     let bestsToDisplay = [
       { label: "Ao100", key: "ao100" },
@@ -140,7 +140,7 @@ export default function SessionsChart({ sessionGroup }) {
     const s = sesh.sd;
     const m = sesh.mean;
     xVals.forEach((n) => data.push({ near: n, pdf: lognormalpdf(n, s, m) }));
-    const labelCommon = { style: { textAnchor: "middle" }, fill: axesColor };
+    // const labelCommon = { style: { textAnchor: "middle" }, fill: axesColor };
 
     return (
       <>

--- a/src/components/trainSettings.jsx
+++ b/src/components/trainSettings.jsx
@@ -25,11 +25,14 @@ export default function TrainSettings() {
     return newData;
   }
 
-  useEffect(async () => {
-    if (userDoc) {
-      const trainSettings = userDoc.data()?.settings?.trainSettings;
-      if (trainSettings) setData(trainSettings);
+  useEffect(() => {
+    async function makeDoName() {
+      if (userDoc) {
+        const trainSettings = userDoc.data()?.settings?.trainSettings;
+        if (trainSettings) setData(trainSettings);
+      }
     }
+    makeDoName();
   }, [userDoc]);
 
   const schema = {

--- a/src/hooks/useCaseSets.jsx
+++ b/src/hooks/useCaseSets.jsx
@@ -79,10 +79,10 @@ const getMergedCaseSets = (localCaseSets, snapshot, userDoc) => {
 export function useCaseSets(user, userDoc) {
   const [caseSets, setCaseSets] = useState();
 
-  const loadingUser = typeof user === "undefined";
-  const loadingUserDoc = typeof userDoc === "undefined";
   useEffect(() => {
     let unsubscribe = () => {};
+    const loadingUser = typeof user === "undefined";
+    const loadingUserDoc = typeof userDoc === "undefined";
     if (!loadingUser && !loadingUserDoc) {
       if (user) {
         unsubscribe = getUserDocRef(user)

--- a/src/hooks/useMainSessionGroup.jsx
+++ b/src/hooks/useMainSessionGroup.jsx
@@ -3,10 +3,10 @@ import { getMainSessionGroupDocRef } from "../services/firebase";
 
 export default function useMainSessionGroup(user) {
   const [sessionGroupDoc, setSessionGroupDoc] = useState();
-  const loadingUser = typeof user === "undefined";
 
   useEffect(() => {
     let unsubscribe = () => {};
+    const loadingUser = typeof user === "undefined";
     if (!loadingUser) {
       if (user) {
         const sessionGroupDocRef = getMainSessionGroupDocRef(user);

--- a/src/hooks/useUserDoc.jsx
+++ b/src/hooks/useUserDoc.jsx
@@ -3,9 +3,9 @@ import { usersRef } from "../services/firebase";
 
 export default function useUserDoc(user) {
   const [userDoc, setUserDoc] = useState();
-  const loadingUser = typeof user === "undefined";
 
   useEffect(() => {
+    const loadingUser = typeof user === "undefined";
     let unsubscribe = () => {};
     if (!loadingUser) {
       if (user) {

--- a/src/utils/scrambles/caseScramble.js
+++ b/src/utils/scrambles/caseScramble.js
@@ -44,7 +44,9 @@ function CornMult(a, b, prod) {
     ori = oriA;
     ori += oriA < 3 ? oriB : 6 - oriB;
     ori %= 3;
-    oriA >= 3 !== oriB >= 3 && (ori += 3);
+    const cond1 = oriA >= 3;
+    const cond2 = oriB >= 3;
+    cond1 !== cond2 && (ori += 3);
     prod.co[corn] = ori;
   }
 }
@@ -70,7 +72,6 @@ function EdgeMult(a, b, prod) {
 }
 
 function initMove() {
-  initMove = Function.prototype;
   var a, p;
   moveCube[0] = new CubieCube1(15120, 0, 119750400, 0);
   moveCube[3] = new CubieCube1(21021, 1494, 323403417, 0);
@@ -258,14 +259,14 @@ export function getAnyScramble(_ep, _eo, _cp, _co, maxDepth, _rndapp, _rndpre) {
     for (let i = 0; i < rndpre.length; i++) {
       CornMult(moveCube[rndpre[i]], cc, cc2);
       EdgeMult(moveCube[rndpre[i]], cc, cc2);
-      var tmp = cc2;
+      let tmp = cc2;
       cc2 = cc;
       cc = tmp;
     }
     for (let i = 0; i < rndapp.length; i++) {
       CornMult(cc, moveCube[rndapp[i]], cc2);
       EdgeMult(cc, moveCube[rndapp[i]], cc2);
-      var tmp = cc2;
+      let tmp = cc2;
       cc2 = cc;
       cc = tmp;
     }

--- a/src/utils/scrambles/caseScramble.js
+++ b/src/utils/scrambles/caseScramble.js
@@ -87,7 +87,7 @@ function initMove() {
   }
 }
 
-var _ = (CubieCube1.prototype = CubieCube.prototype);
+// var _ = (CubieCube1.prototype = CubieCube.prototype);
 var moveCube = [];
 var cornerFacelet = [
   [8, 9, 20],

--- a/src/utils/scrambles/min2phase.js
+++ b/src/utils/scrambles/min2phase.js
@@ -1522,7 +1522,7 @@ var min2phase = (function () {
       depth++;
       InitPrunProgress++;
       var xorVal = depth ^ 0xf;
-      var done = 0;
+      // var done = 0;
       var val = 0;
       for (let i = 0; i < N_SIZE; i++, val >>= 4) {
         if ((i & 7) === 0) {
@@ -1567,7 +1567,7 @@ var min2phase = (function () {
             }
             continue;
           }
-          done++;
+          // done++;
           if (inv) {
             setPruning(PrunTable, i, xorVal);
             break;
@@ -1589,7 +1589,7 @@ var min2phase = (function () {
             }
             if (getPruning(PrunTable, idxx) === check) {
               setPruning(PrunTable, idxx, xorVal);
-              done++;
+              // done++;
             }
           }
         }

--- a/src/utils/sessionStats.js
+++ b/src/utils/sessionStats.js
@@ -109,7 +109,7 @@ export const getSessionGroupBests = (sessions) => {
 
 export const getSessionGroupStats = (sessions) => {
   const numSolves = _.sumBy(sessions, "numSolves");
-  const numNonDNFSolves = _.sumBy(sessions, "numNonDNFSolves");
+  // const numNonDNFSolves = _.sumBy(sessions, "numNonDNFSolves");
   const numSessions = sessions.length;
 
   const bests = getSessionGroupBests(sessions);


### PR DESCRIPTION
The GitHub action that deploys this thing automatically, does not allow warnings on build by default. I'm sure there's a way around this and I'm sure it's not a good idea. Warnings exist for a reason and should ideally be fixed before anything goes into production.

> **Side Note:** I didn't actually know that the build warnings were what was stopping the GitHub action before, just figured that out recently

## Warning Types
Most of the warnings fell into one of the following two categories:
### 1. Incomplete useEffect Dependancies ([react-hooks/exhaustive-deps](https://reactjs.org/docs/hooks-rules.html))

React doesn't like when you define `useEffect` hooks and don't put all the dependencies in the dependency array. It's honestly pretty annoying, hard to understand and hard to fix. Some fixes are as easy as just adding the missing dependencies, but most of the time, doing this results in some kind of infinite `useState`-`useEffect` loop that crashes everything. Here are some solutions I found:

1. Putting definitions inside the `useEffect` hook - if you have a certain constant or function that is only used inside the `useEffect` hook, you can simply define it inside the hook and avoid having to include it as a dependency.
2. Taking definitions outside of the parent component - taking the definition of the dependency outside the parent component stops it from being updated every time the component is mounted. Not sure how good of a solution this is but it works for now.
3. Get rid of the `useEffect` hook - if you can refactor your code to work without an effect, yay! Problem solved. This is actually a good way of solving this issue.
4. Ignore the warning - sometimes there just doesn't seem to be a good solution. If this is the case you can ignore the lint warning with: 
   ```javaScript
   // eslint-disable-next-line react-hooks/exhaustive-deps
   ```
### 2. Unused Variables ([eslint/no-unused-vars](https://eslint.org/docs/rules/no-unused-vars))
You declare a variable, you use it for something, you stop using it for that something, the variable remains declared somewhere but unused. This is hardly going to crash anyone's code, but as is stated in the linked documentation:
> *"Such variables take up space in the code and can lead to confusion by readers."*

Solution is comment them out or delete them.
