### PR TITLE
Add reset case set

### DIFF
--- a/src/components/caseSetDashboard.jsx
+++ b/src/components/caseSetDashboard.jsx
@@ -1,18 +1,29 @@
-import React, { useContext } from "react";
-import { Button, Col, Row } from "react-bootstrap";
+import React, { useContext, useState } from "react";
+import { Button, Col, Modal, Row } from "react-bootstrap";
 import { FaIcon } from "../fontAwesome";
 import _ from "lodash";
 import BackButton from "./common/backButton";
 import CaseSetsContext from "../hooks/useCaseSets";
+import { UserContext } from "../services/firebase";
 import SelectCaseSet from "./selectCaseSet";
 import CaseSetTable from "./caseSetTable";
+import resetCaseSet from "../utils/resetCaseSet";
 
 function CaseSetDashboard(props) {
   const { caseSetDetails, setCaseSetDetails } = props;
   const { selectedCases, setSelectedCases } = props;
   const { onTest, onLearn } = props;
   const caseSets = useContext(CaseSetsContext);
+  const { user } = useContext(UserContext);
   const selectedCaseSet = _(caseSets).find(["details.id", caseSetDetails?.id]);
+  const [showResetModal, setShowResetModal] = useState(false);
+
+  const title = selectedCaseSet?.details?.title;
+
+  const handleResetConfirm = async () => {
+    await resetCaseSet(user, caseSetDetails);
+    setShowResetModal(false);
+  };
 
   return (
     caseSets && (
@@ -23,8 +34,16 @@ function CaseSetDashboard(props) {
         {selectedCaseSet && (
           <>
             <Row>
-              <Col className="p-0">
+              <Col className="d-flex align-items-center p-0">
                 <BackButton onClick={() => setCaseSetDetails(null)} />
+                <Button
+                  variant="outline-danger"
+                  size="sm"
+                  className="m-1"
+                  onClick={() => setShowResetModal(true)}
+                >
+                  <FaIcon icon="redo" /> Reset
+                </Button>
               </Col>
               <Col className="justify-content-end d-flex p-0">
                 <Button
@@ -49,6 +68,26 @@ function CaseSetDashboard(props) {
               caseSet={selectedCaseSet}
               setSelectedCases={setSelectedCases}
             />
+            <Modal show={showResetModal} onHide={() => setShowResetModal(false)}>
+              <Modal.Header closeButton>
+                <Modal.Title>Reset {title}?</Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+                This will permanently delete all solve history and stats for{" "}
+                {title}. Chosen algorithms will be kept.
+              </Modal.Body>
+              <Modal.Footer>
+                <Button
+                  variant="secondary"
+                  onClick={() => setShowResetModal(false)}
+                >
+                  Cancel
+                </Button>
+                <Button variant="danger" onClick={handleResetConfirm}>
+                  Reset
+                </Button>
+              </Modal.Footer>
+            </Modal>
           </>
         )}
       </>

--- a/src/utils/resetCaseSet.js
+++ b/src/utils/resetCaseSet.js
@@ -1,0 +1,28 @@
+import { collection, getDocs, getDoc, updateDoc, setDoc, deleteField } from "@firebase/firestore";
+import { getCaseSetDocRef } from "../services/firebase";
+
+export default async function resetCaseSet(user, caseSetDetails) {
+  const caseSetDocRef = getCaseSetDocRef(user, caseSetDetails);
+  const casesCollRef = collection(caseSetDocRef, "cases");
+
+  // Clear stats from all case sub-docs, keep alg
+  const caseDocs = await getDocs(casesCollRef);
+  await Promise.all(
+    caseDocs.docs.map((d) =>
+      updateDoc(d.ref, {
+        caseStats: deleteField(),
+        recentCaseSolves: deleteField(),
+      })
+    )
+  );
+
+  // Clear caseStats from main doc, keep id + alg per case
+  const caseSetDoc = await getDoc(caseSetDocRef);
+  const data = caseSetDoc.data();
+  if (data?.cases) {
+    const resetCases = data.cases.map(({ id, alg }) =>
+      alg ? { id, alg } : { id }
+    );
+    await setDoc(caseSetDocRef, { cases: resetCases });
+  }
+}


### PR DESCRIPTION
Adds a Reset button to the CaseSetDashboard toolbar that clears all solve history/stats for a case set while preserving chosen algorithms.

- New `resetCaseSet` util clears `caseStats` + `recentCaseSolves` from case sub-docs and strips `caseStats` from the main doc's cases array
- Reset button (outline-danger) in toolbar opens a confirmation modal before acting